### PR TITLE
chore: removed unused tailwind forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"@storybook/nextjs": "7.2.2",
 		"@storybook/react": "7.2.2",
 		"@storybook/testing-library": "^0.2.0",
-		"@tailwindcss/forms": "0.5.4",
 		"@tailwindcss/line-clamp": "0.4.4",
 		"@tailwindcss/typography": "0.5.9",
 		"@technologiestiftung/semantic-release-config": "1.2.3",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -102,6 +102,5 @@ module.exports = {
 	plugins: [
 		require("@tailwindcss/line-clamp"),
 		require("@tailwindcss/typography"),
-		require("@tailwindcss/forms"),
 	],
 };


### PR DESCRIPTION
removed the unused library tailwind forms that added styles that we did not need